### PR TITLE
fix: new possible proto name

### DIFF
--- a/lib/grpc_loader.js
+++ b/lib/grpc_loader.js
@@ -47,7 +47,7 @@ module.exports = app => {
           /* istanbul ignore next */
           if (this.circular) this.remove();
 
-          if (proto.name === 'Client') {
+          if (proto.name === 'Client' || proto.name === 'ServiceClient') {
             const properties = this.path.map(camelize);
             proto.paths = properties;
             const item = {
@@ -60,6 +60,8 @@ module.exports = app => {
             debug('register grpc service: %s', properties.join('.'));
           } else if (proto.name === 'Message') {
             this.update(proto, true);
+          } else {
+            console.warn('[grpc_loader] unknown proto.name: %s', proto.name);
           }
         });
       }

--- a/test/pkg.test.js
+++ b/test/pkg.test.js
@@ -23,7 +23,7 @@ describe('test/pkg.test.js', () => {
     // check proto
     const testProto = app.grpcProto.egg.test;
     assert(testProto.GameInfoList.name === 'Message');
-    assert(testProto.GameInfoService.name === 'Client');
+    assert(testProto.GameInfoService.name === 'Client' || testProto.GameInfoService.name === 'ServiceClient');
     assert(testProto.GameInfoService.service.listAll);
 
     // don't care your real path


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
grpc loader

##### Description of change
<!-- Provide a description of the change below this comment. -->
Type name of service that loaded by `grpc@1.4.1` changed from `Client` to `ServiceClient`.