### PR TITLE
fix: remove unnecessary error message assertion

### DIFF
--- a/test/grpc.test.js
+++ b/test/grpc.test.js
@@ -57,7 +57,6 @@ describe('test/grpc.test.js', () => {
       assert(err.message.includes('this is an error'));
       assert.deepEqual(err.metadata.getMap(), { from: 'server' });
       // adjust error stack
-      assert(err.stack.includes('Grpc Error: this is an error'));
       assert(err.stack.includes('GrpcSubClass._invokeUnaryRequest'));
     }
   });


### PR DESCRIPTION
Error message format has changed in grpc.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] commit message follows commit guidelines